### PR TITLE
后台用户配置权限时不选择《设置》菜单，登录会报错，配置时无任何提示，且可以选择不配置，bug

### DIFF
--- a/crmeb/src/main/java/com/zbkj/crmeb/config/WebConfig.java
+++ b/crmeb/src/main/java/com/zbkj/crmeb/config/WebConfig.java
@@ -87,6 +87,8 @@ public class WebConfig implements WebMvcConfigurer {
                 excludePathPatterns("/api/admin/login").
                 excludePathPatterns("/api/admin/logout").
                 excludePathPatterns("/api/admin/getLoginPic").
+                excludePathPatterns("/api/admin/system/role/info").
+                excludePathPatterns("/api/admin/system/role/menu").
                 excludePathPatterns("/api/admin/payment/callback/**").
                 excludePathPatterns("/swagger-resources/**", "/webjars/**", "/v2/**", "/swagger-ui.html/**");
 


### PR DESCRIPTION
后台用户配置权限时不选择《设置》菜单，登录会报错，配置时无任何提示，且可以选择不配置，bug。应该忽略掉这两个页面，因为前段不管你配置没有，都会请求。