### PR TITLE
fix: 响应输出编码不一致

### DIFF
--- a/crmeb/crmeb-admin/src/main/java/com/zbkj/admin/filter/ResponseFilter.java
+++ b/crmeb/crmeb-admin/src/main/java/com/zbkj/admin/filter/ResponseFilter.java
@@ -61,7 +61,7 @@ public class ResponseFilter implements Filter {
             //把返回值输出到客户端
             ServletOutputStream outputStream = response.getOutputStream();
             if (str.length() > 0) {
-                outputStream.write(str.getBytes());
+                outputStream.write(str.getBytes(StandardCharsets.UTF_8));
                 outputStream.flush();
                 outputStream.close();
                 //最后添加这一句，输出到客户端

--- a/crmeb/crmeb-front/src/main/java/com/zbkj/front/filter/ResponseFilter.java
+++ b/crmeb/crmeb-front/src/main/java/com/zbkj/front/filter/ResponseFilter.java
@@ -50,7 +50,7 @@ public class ResponseFilter implements Filter {
             //把返回值输出到客户端
             ServletOutputStream outputStream = response.getOutputStream();
             if (str.length() > 0) {
-                outputStream.write(str.getBytes());
+                outputStream.write(str.getBytes(StandardCharsets.UTF_8));
                 outputStream.flush();
                 outputStream.close();
                 //最后添加这一句，输出到客户端


### PR DESCRIPTION
明确指定字符编码。

当主机编码配置异常时，会出现如下图所示乱码：

<div align="center"> <img src="https://github.com/user-attachments/assets/a9131b1a-c8f2-405e-a420-66a3fce56330" alt="主机编码异常导致的乱码界面" width="80%" /> <br> <em>图：主机编码配置异常导致的乱码显示</em> </div>